### PR TITLE
Don't check texture.image until after dup check

### DIFF
--- a/src/UnlitBatchShader.ts
+++ b/src/UnlitBatchShader.ts
@@ -74,7 +74,7 @@ export class BatchRawUniformGroup extends RawUniformsGroup {
     const instanceId = this.nextId();
     const material = mesh.material;
 
-    if (material.map && material.map.image) {
+    if (material.map) {
       const textureId = atlas.addTexture(material.map, tempUvTransform);
 
       if (textureId === undefined) {

--- a/src/WebGLAtlasTexture.ts
+++ b/src/WebGLAtlasTexture.ts
@@ -299,6 +299,13 @@ export default class WebGLAtlasTexture extends Texture {
     }
 
     const img = texture.image;
+
+    // TODO We should also check for a GL texture existing before giving up
+    if (!img) {
+      console.warn("Attempted to add a texture with no image to the atlas");
+      return;
+    }
+
     let width = img.width;
     let height = img.height;
     let size;
@@ -346,6 +353,10 @@ export default class WebGLAtlasTexture extends Texture {
       count: 1,
       uvTransform: uvTransform.slice()
     });
+
+    if (texture.onUpdate) {
+      texture.onUpdate();
+    }
 
     return id;
   }


### PR DESCRIPTION
In Hubs we dispose of textures after we upload them to the GPU, this PR adds 2 changes to allow that to work:
1. Call `onUpdate` on the texture when it is first added to the atlas (So that Hubs can dispose of the original Image after it is added to the atlas).
2. Allow adding additional refs of textures without images as long as they are already in the atlas (this allows  the atlas to correctly keep count of texture references even after the backing image has been disposed of). We should also probably allow adding textures with no image if they have a valid GL texture associated with them, but leaving that as TODO for later,

This also required a change in how Hubs does GLTF caching sch that we don't keep them around forever (which we really shouldnt have anyway), since after all instances of a texture were removed from the atlas, you would still be left with a reference to a now unusable Texture in the GLTF cache.
