### PR TITLE
Workaround for broken blitFramebuffer for non 0 layrers on android

### DIFF
--- a/src/WebGLAtlasTexture.ts
+++ b/src/WebGLAtlasTexture.ts
@@ -532,8 +532,6 @@ export default class WebGLAtlasTexture extends Texture {
     state.bindTexture(gl.TEXTURE_2D_ARRAY, this.glTexture);
     const mips = this.mipFramebuffers[layerIdx];
     while (curSize >= 1) {
-      // gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, mips[mipLevel]);
-
       const srcX = r * prevSize;
       const srcY = c * prevSize;
       const srcX2 = srcX + prevSize;

--- a/src/WebGLAtlasTexture.ts
+++ b/src/WebGLAtlasTexture.ts
@@ -227,11 +227,7 @@ export default class WebGLAtlasTexture extends Texture {
     debug.style.position = "absolute";
     debug.style.top = debug.style.bottom = debug.style.left = debug.style.right = "0";
     debug.style.overflow = "scroll";
-    debug.style.backgroundImage =
-      "linear-gradient(45deg, #808080 25%, transparent 25%), linear-gradient(-45deg, #808080 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #808080 75%), linear-gradient(-45deg, transparent 75%, #808080 75%)";
-    debug.style.backgroundSize = "20px 20px";
-    debug.style.backgroundPosition = "0 0, 0 10px, 10px -10px, -10px 0px";
-    debug.style.backgroundColor = "white";
+    debug.style.background = "black";
 
     const mips = this.mipFramebuffers[layer];
     for (let mipLevel = 0; mipLevel < Math.log2(this.layerResolution) + 1; mipLevel++) {
@@ -240,6 +236,12 @@ export default class WebGLAtlasTexture extends Texture {
       const c = document.createElement("canvas") as HTMLCanvasElement;
       c.width = c.height = this.layerResolution / Math.pow(2, mipLevel);
       c.style.display = "block";
+      c.style.backgroundImage =
+        "linear-gradient(45deg, #808080 25%, transparent 25%), linear-gradient(-45deg, #808080 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #808080 75%), linear-gradient(-45deg, transparent 75%, #808080 75%)";
+      c.style.backgroundSize = "20px 20px";
+      c.style.backgroundPosition = "0 0, 0 10px, 10px -10px, -10px 0px";
+      c.style.backgroundColor = "white";
+
       const ctx = c.getContext("2d");
       const imgData = ctx.createImageData(c.width, c.height);
 
@@ -254,6 +256,7 @@ export default class WebGLAtlasTexture extends Texture {
     document.body.appendChild(debug);
 
     gl.deleteFramebuffer(fb);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
   }
 
   growTextureArray(newDepth: number) {


### PR DESCRIPTION
`blitFramebuffer` does not work correctly when blitting to non 0 layers of a texture array (see ttps://jsfiddle.net/nu1xdgs3/13a for a simplified testcase). Similarly `copyTexSubImage3D` does not work correctly when copying from non 0 layers of a texture array. This PR works around this by first blitting to a temporary (non array) texture and then copying from that to the destination layer. 

We should perform a quick test for this defect on startup and only perform the workaround when needed, but for now it is always used.