### PR TITLE
Improve mipmapping

### DIFF
--- a/src/WebGLAtlasTexture.ts
+++ b/src/WebGLAtlasTexture.ts
@@ -364,10 +364,15 @@ export default class WebGLAtlasTexture extends Texture {
 
     const layer = this.layers[layerIdx];
 
-    uvTransform[0] = (atlasIdx % layer.colls) / layer.colls;
-    uvTransform[1] = Math.floor(atlasIdx / layer.rows) / layer.rows;
-    uvTransform[2] = (1 / layer.colls) * (width / layer.size);
-    uvTransform[3] = (1 / layer.rows) * (height / layer.size);
+    // We want to target the center of each texel
+    const halfTexel = 0.5 / this.layerResolution;
+    uvTransform[0] = (atlasIdx % layer.colls) / layer.colls + halfTexel;
+    uvTransform[1] = Math.floor(atlasIdx / layer.rows) / layer.rows + halfTexel;
+    // We want to subtract half a pixel from the left and right, so the width/height is -1
+    uvTransform[2] = (1 / layer.colls) * ((width - 1) / layer.size);
+    uvTransform[3] = (1 / layer.rows) * ((height - 1) / layer.size);
+
+    console.log(uvTransform[0], uvTransform[1], uvTransform[2], uvTransform[3]);
 
     if (texture.flipY) {
       uvTransform[1] = uvTransform[1] + uvTransform[3];
@@ -394,10 +399,11 @@ export default class WebGLAtlasTexture extends Texture {
 
     this.clearTile(id, color);
 
-    uvTransform[0] = (atlasIdx % layer.colls) / layer.colls;
-    uvTransform[1] = Math.floor(atlasIdx / layer.rows) / layer.rows;
-    uvTransform[2] = (1 / layer.colls) * (size / layer.size);
-    uvTransform[3] = (1 / layer.rows) * (size / layer.size);
+    const halfTexel = 0.5 / this.layerResolution;
+    uvTransform[0] = (atlasIdx % layer.colls) / layer.colls + halfTexel;
+    uvTransform[1] = Math.floor(atlasIdx / layer.rows) / layer.rows + halfTexel;
+    uvTransform[2] = (1 / layer.colls) * ((size - 1) / layer.size);
+    uvTransform[3] = (1 / layer.rows) * ((size - 1) / layer.size);
 
     return id;
   }

--- a/src/WebGLAtlasTexture.ts
+++ b/src/WebGLAtlasTexture.ts
@@ -240,8 +240,8 @@ export default class WebGLAtlasTexture extends Texture {
       c.style.display = "block";
       c.style.backgroundImage =
         "linear-gradient(45deg, #808080 25%, transparent 25%), linear-gradient(-45deg, #808080 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #808080 75%), linear-gradient(-45deg, transparent 75%, #808080 75%)";
-      c.style.backgroundSize = "20px 20px";
-      c.style.backgroundPosition = "0 0, 0 10px, 10px -10px, -10px 0px";
+      c.style.backgroundSize = "64px 64px";
+      c.style.backgroundPosition = "0 0, 0 32px, 32px -32px, -32px 0px";
       c.style.backgroundColor = "white";
 
       const ctx = c.getContext("2d");

--- a/src/WebGLAtlasTexture.ts
+++ b/src/WebGLAtlasTexture.ts
@@ -231,6 +231,12 @@ export default class WebGLAtlasTexture extends Texture {
     debug.style.overflow = "scroll";
     debug.style.background = "black";
 
+    const close = document.createElement("button");
+    close.innerText = "close";
+    debug.appendChild(close);
+    close.addEventListener("click", () => document.body.removeChild(debug), { once: true });
+    close.style.marginBottom = "10px";
+
     const mips = this.mipFramebuffers[layer];
     for (let mipLevel = 0; mipLevel < this.mipLevels; mipLevel++) {
       gl.bindFramebuffer(gl.FRAMEBUFFER, mips[mipLevel]);
@@ -243,6 +249,7 @@ export default class WebGLAtlasTexture extends Texture {
       c.style.backgroundSize = "64px 64px";
       c.style.backgroundPosition = "0 0, 0 32px, 32px -32px, -32px 0px";
       c.style.backgroundColor = "white";
+      c.style.marginBottom = "10px";
 
       const ctx = c.getContext("2d");
       const imgData = ctx.createImageData(c.width, c.height);

--- a/src/WebGLAtlasTexture.ts
+++ b/src/WebGLAtlasTexture.ts
@@ -379,8 +379,6 @@ export default class WebGLAtlasTexture extends Texture {
     uvTransform[2] = (1 / layer.colls) * ((width - 1) / layer.size);
     uvTransform[3] = (1 / layer.rows) * ((height - 1) / layer.size);
 
-    console.log(uvTransform[0], uvTransform[1], uvTransform[2], uvTransform[3]);
-
     if (texture.flipY) {
       uvTransform[1] = uvTransform[1] + uvTransform[3];
       uvTransform[3] = -uvTransform[3];
@@ -489,7 +487,6 @@ export default class WebGLAtlasTexture extends Texture {
     gl.bindFramebuffer(gl.FRAMEBUFFER, resizeFramebuffer);
     gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, resizeTexture, 0);
 
-    console.log("Uploading image with resize", width, height, img);
     // Blitting to a non 0 layer is broken on mobile, workaround by blitting then copying
     // see https://jsfiddle.net/nu1xdgs3/13a
     const blitCopyHackTexture = gl.createTexture();

--- a/src/WebGLAtlasTexture.ts
+++ b/src/WebGLAtlasTexture.ts
@@ -543,7 +543,7 @@ export default class WebGLAtlasTexture extends Texture {
 
     state.bindTexture(gl.TEXTURE_2D_ARRAY, this.glTexture);
     const mips = this.mipFramebuffers[layerIdx];
-    while (curSize >= 1 && mipLevel <= this.mipLevels) {
+    while (curSize >= 2 && mipLevel <= this.mipLevels) {
       const srcX = r * prevSize;
       const srcY = c * prevSize;
       const srcX2 = srcX + prevSize;
@@ -551,8 +551,8 @@ export default class WebGLAtlasTexture extends Texture {
 
       const destX = r * curSize;
       const destY = c * curSize;
-      const destX2 = destX + curSize;
-      const destY2 = destY + curSize;
+      // const destX2 = destX + curSize;
+      // const destY2 = destY + curSize;
 
       gl.bindFramebuffer(gl.READ_FRAMEBUFFER, mips[mipLevel - 1]);
       gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, blitCopyHackFB);


### PR DESCRIPTION
This PR improves mipmapping a texture bleeding a bit by:
- Modifying the UV transform so that the edges land on the center of texels rather than the edges
- Only generating mipmaps down to log2(minTileSize) since we know for sure below that we are always just blending tiles together. Also never generate 1px mip as that throws a gl error and doesn't seem useful anyway.
- Slightly improving the mip debug output