### PR TITLE
Prevent adding mesh to the batch more than once

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -296,6 +296,11 @@ export class BatchManager {
 
     const batchableMesh = mesh as BatchableMesh;
 
+    if (this.batchForMesh.has(batchableMesh)) {
+      console.warn("Mesh is already in the batch, skipping.", mesh);
+      return false;
+    }
+
     if (Array.isArray(mesh.material)) {
       console.warn("Mesh uses unsupported multi-material, skipping.", mesh);
       return false;


### PR DESCRIPTION
Currently you can add the same instance of a mesh to the batch more than once. This PR prevents that from happening and warns you when you try.