### PR TITLE
Fix image batching on macOS

### DIFF
--- a/example/basic-image-batching.html
+++ b/example/basic-image-batching.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>THREE Render Manager Basic Image Batching Example</title>
+    <style>
+      html, body {
+        margin: 0;
+      }
+
+      #canvas {
+        display: block;
+        width: 100vw;
+        height: 100vh;
+        background-color: white;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="canvas"></canvas>
+  </body>
+</html>

--- a/example/basic-image-batching.ts
+++ b/example/basic-image-batching.ts
@@ -1,0 +1,106 @@
+import {
+  TextureLoader,
+  MeshBasicMaterial,
+  PlaneBufferGeometry,
+  Mesh,
+  DoubleSide,
+  WebGLRenderer,
+  Scene,
+  AmbientLight,
+  PerspectiveCamera,
+  Clock,
+  Texture,
+  AxesHelper,
+  Color
+} from "three";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
+import { BatchManager } from "../src/index";
+
+console.log(navigator.userAgent);
+
+const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+const context = canvas.getContext("webgl2", { antialias: true });
+
+const renderer = new WebGLRenderer({ canvas, context });
+renderer.debug.checkShaderErrors = true;
+renderer.setPixelRatio(window.devicePixelRatio);
+renderer.setSize(window.innerWidth, window.innerHeight);
+
+const scene = new Scene();
+
+scene.add(new AmbientLight(0x404040));
+
+const camera = new PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+camera.position.set(3.42, 3.4, 2.38);
+camera.lookAt(0, 0, 0);
+scene.add(camera);
+
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.target.set(0, 0, 0);
+controls.update();
+
+const batchManager = new BatchManager(scene, renderer);
+
+function loadTexture(url: string): Promise<Texture> {
+  return new Promise((resolve, reject) =>
+    new TextureLoader().load(url, resolve, undefined, () => reject(new Error(`Failed to load image: "${url}"`)))
+  );
+}
+
+let lastFrame = 0;
+const nonBatchedColor = new Color().setRGB(Math.random() * 10, Math.random() * 10, Math.random() * 10);
+const nonBatchedMatrials: MeshBasicMaterial[] = [];
+
+function addImage(texture: Texture) {
+  const imageGeometry = new PlaneBufferGeometry();
+  const imageMaterial = new MeshBasicMaterial({ map: texture });
+  imageMaterial.side = DoubleSide;
+  const imageMesh = new Mesh(imageGeometry, imageMaterial);
+  scene.add(imageMesh);
+
+  if (!batchManager.addMesh(imageMesh)) {
+    const material = imageMesh.material as MeshBasicMaterial;
+    nonBatchedMatrials.push(material);
+  }
+
+  return imageMesh;
+}
+
+(async function loadScene() {
+  const firefoxLogoTexture = await loadTexture("./FirefoxLogo.png");
+
+  const logo1 = addImage(firefoxLogoTexture);
+  logo1.position.set(0, 1.5, 0);
+
+  const logo2 = addImage(firefoxLogoTexture);
+  logo2.position.set(2, 1.5, 0);
+
+  scene.add(new AxesHelper(1));
+})().catch(console.error);
+
+const clock = new Clock();
+
+function render() {
+  const time = clock.getElapsedTime();
+
+  const curFrame = Math.round(time) % 2;
+
+  if (lastFrame !== curFrame) {
+    lastFrame = curFrame;
+    nonBatchedColor.setRGB(Math.random() * 10, Math.random() * 10, Math.random() * 10);
+  }
+
+  for (let i = 0; i < nonBatchedMatrials.length; i++) {
+    nonBatchedMatrials[i].color.copy(nonBatchedColor);
+  }
+
+  batchManager.update(time);
+
+  renderer.render(scene, camera);
+}
+
+renderer.setAnimationLoop(render);
+
+(window as any).renderer = renderer;
+(window as any).scene = scene;
+(window as any).batchManager = batchManager;

--- a/example/basic-image-batching.ts
+++ b/example/basic-image-batching.ts
@@ -16,8 +16,6 @@ import {
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import { BatchManager } from "../src/index";
 
-console.log(navigator.userAgent);
-
 const canvas = document.getElementById("canvas") as HTMLCanvasElement;
 const context = canvas.getContext("webgl2", { antialias: true });
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,5 +1,4 @@
 import {
-  Vector3,
   TextureLoader,
   MeshBasicMaterial,
   PlaneBufferGeometry,
@@ -15,9 +14,7 @@ import {
   DirectionalLight,
   Texture,
   AxesHelper,
-  Material,
-  Color,
-  MeshStandardMaterial
+  Color
 } from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import { GLTFLoader, GLTF } from "three/examples/jsm/loaders/GLTFLoader";

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -5,10 +5,13 @@ const webpack = require("webpack");
 module.exports = {
   mode: "development",
   devtool: "inline-source-map",
-  entry: path.join(__dirname, "index.ts"),
+  entry: {
+    index: path.join(__dirname, "index.ts"),
+    "basic-image-batching": path.join(__dirname, "basic-image-batching.ts")
+  },
   output: {
     path: path.resolve(__dirname, "dist"),
-    filename: "bundle.js"
+    filename: "[name].js"
   },
   resolve: {
     extensions: [".ts", ".js"]
@@ -21,7 +24,14 @@ module.exports = {
   },
   plugins: [
     new HTMLWebpackPlugin({
-      template: path.join(__dirname, "index.html")
+      filename: "index.html",
+      template: path.join(__dirname, "index.html"),
+      chunks: ["index"]
+    }),
+    new HTMLWebpackPlugin({
+      filename: "basic-image-batching.html",
+      template: path.join(__dirname, "basic-image-batching.html"),
+      chunks: ["basic-image-batching"]
     }),
     new webpack.ProvidePlugin({
       THREE: "three"

--- a/src/WebGLAtlasTexture.ts
+++ b/src/WebGLAtlasTexture.ts
@@ -116,7 +116,7 @@ export default class WebGLAtlasTexture extends Texture {
 
     this.flipY = false;
 
-    this.createTextureArray(1);
+    this.createTextureArray(3);
 
     this.nullTextureTransform = [0, 0, 0, 0];
     this.nullTextureIndex = this.addColorRect(this.minTileSize, [1, 1, 1, 1], this.nullTextureTransform);

--- a/src/WebGLAtlasTexture.ts
+++ b/src/WebGLAtlasTexture.ts
@@ -1,4 +1,4 @@
-import { Texture, Math as ThreeMath, WebGLRenderer } from "three";
+import { Texture, Math as ThreeMath, WebGLRenderer, WebGLState } from "three";
 
 export type TileID = number;
 export type LayerID = number;
@@ -58,6 +58,32 @@ export interface WebGLAtlasTextureOptions {
   maxLayers?: number;
 }
 
+// Blitting to a non 0 layer is broken on mobile, workaround by blitting then copying
+// see https://jsfiddle.net/nu1xdgs3/13a
+// This hack breaks mip map generation on some Mac OS computers, so we disable it there.
+const useBlitHack = !/mac os/i.test(navigator.userAgent);
+
+function createBlitCopyFramebuffer(
+  gl: WebGL2RenderingContext,
+  state: WebGLState,
+  width: number,
+  height: number,
+  target: WebGLTexture
+) {
+  if (!useBlitHack) {
+    return [null, null];
+  }
+  const blitCopyHackTexture = gl.createTexture();
+  const blitCopyHackFB = gl.createFramebuffer();
+  state.activeTexture(gl.TEXTURE0);
+  state.bindTexture(gl.TEXTURE_2D, blitCopyHackTexture);
+  gl.bindFramebuffer(gl.FRAMEBUFFER, blitCopyHackFB);
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, blitCopyHackTexture, 0);
+  gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA8, width, height);
+  state.bindTexture(gl.TEXTURE_2D_ARRAY, target);
+  return [blitCopyHackTexture, blitCopyHackFB];
+}
+
 export default class WebGLAtlasTexture extends Texture {
   renderer: WebGLRenderer;
   layerResolution: number;
@@ -90,7 +116,7 @@ export default class WebGLAtlasTexture extends Texture {
 
     this.flipY = false;
 
-    this.createTextureArray(3);
+    this.createTextureArray(1);
 
     this.nullTextureTransform = [0, 0, 0, 0];
     this.nullTextureIndex = this.addColorRect(this.minTileSize, [1, 1, 1, 1], this.nullTextureTransform);
@@ -269,7 +295,7 @@ export default class WebGLAtlasTexture extends Texture {
   }
 
   growTextureArray(newDepth: number) {
-    const { state, properties } = this.renderer;
+    const { state } = this.renderer;
     const gl = this.renderer.context as WebGL2RenderingContext;
 
     const prevGlTexture = this.glTexture;
@@ -277,35 +303,35 @@ export default class WebGLAtlasTexture extends Texture {
     const prevMipFramebuffers = this.mipFramebuffers;
 
     this.createTextureArray(newDepth);
-    console.log("Growing array to", newDepth);
 
-    // Blitting to a non 0 layer is broken on mobile, workaround by blitting then copying
-    // see https://jsfiddle.net/nu1xdgs3/13a
-    const blitCopyHackTexture = gl.createTexture();
-    const blitCopyHackFB = gl.createFramebuffer();
-    state.activeTexture(gl.TEXTURE0);
-    state.bindTexture(gl.TEXTURE_2D, blitCopyHackTexture);
-    gl.bindFramebuffer(gl.FRAMEBUFFER, blitCopyHackFB);
-    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, blitCopyHackTexture, 0);
-    gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA8, this.layerResolution, this.layerResolution);
+    const [blitCopyHackTexture, blitCopyHackFB] = createBlitCopyFramebuffer(
+      gl,
+      state,
+      this.layerResolution,
+      this.layerResolution,
+      this.glTexture
+    );
 
-    state.bindTexture(gl.TEXTURE_2D_ARRAY, this.glTexture);
     const maxMipLevels = this.mipLevels;
     for (let z = 0; z < prevArrayDepth; z++) {
       for (let mipLevel = 0; mipLevel < maxMipLevels; mipLevel++) {
         const res = this.layerResolution / Math.pow(2, mipLevel);
 
         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, prevMipFramebuffers[z][mipLevel]);
-        gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, blitCopyHackFB);
+        gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, useBlitHack ? blitCopyHackFB : this.mipFramebuffers[z][mipLevel]);
         gl.blitFramebuffer(0, 0, res, res, 0, 0, res, res, gl.COLOR_BUFFER_BIT, gl.NEAREST);
 
-        gl.bindFramebuffer(gl.READ_FRAMEBUFFER, blitCopyHackFB);
-        gl.copyTexSubImage3D(gl.TEXTURE_2D_ARRAY, mipLevel, 0, 0, z, 0, 0, res, res);
+        if (useBlitHack) {
+          gl.bindFramebuffer(gl.READ_FRAMEBUFFER, blitCopyHackFB);
+          gl.copyTexSubImage3D(gl.TEXTURE_2D_ARRAY, mipLevel, 0, 0, z, 0, 0, res, res);
+        }
       }
     }
 
-    gl.deleteTexture(blitCopyHackTexture);
-    gl.deleteFramebuffer(blitCopyHackFB);
+    if (useBlitHack) {
+      gl.deleteTexture(blitCopyHackTexture);
+      gl.deleteFramebuffer(blitCopyHackFB);
+    }
 
     for (let z = 0; z < prevMipFramebuffers.length; z++) {
       const mips = prevMipFramebuffers[z];
@@ -487,32 +513,42 @@ export default class WebGLAtlasTexture extends Texture {
     gl.bindFramebuffer(gl.FRAMEBUFFER, resizeFramebuffer);
     gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, resizeTexture, 0);
 
-    // Blitting to a non 0 layer is broken on mobile, workaround by blitting then copying
-    // see https://jsfiddle.net/nu1xdgs3/13a
-    const blitCopyHackTexture = gl.createTexture();
-    const blitCopyHackFB = gl.createFramebuffer();
-    state.bindTexture(gl.TEXTURE_2D, blitCopyHackTexture);
-    gl.bindFramebuffer(gl.FRAMEBUFFER, blitCopyHackFB);
-    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, blitCopyHackTexture, 0);
-    gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA8, width, height);
+    const [blitCopyHackTexture, blitCopyHackFB] = createBlitCopyFramebuffer(gl, state, width, height, this.glTexture);
 
     const layer = this.layers[layerIdx];
     const xOffset = (atlasIdx % layer.colls) * layer.size;
     const yOffset = Math.floor(atlasIdx / layer.rows) * layer.size;
 
     gl.bindFramebuffer(gl.READ_FRAMEBUFFER, resizeFramebuffer);
-    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, blitCopyHackFB);
-    gl.blitFramebuffer(0, 0, img.width, img.height, 0, 0, width, height, gl.COLOR_BUFFER_BIT, gl.LINEAR);
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, useBlitHack ? blitCopyHackFB : this.mipFramebuffers[layerIdx][0]);
+    const blitXOffset = useBlitHack ? 0 : xOffset;
+    const blitYOffset = useBlitHack ? 0 : yOffset;
+    gl.blitFramebuffer(
+      0,
+      0,
+      img.width,
+      img.height,
+      blitXOffset,
+      blitYOffset,
+      blitXOffset + width,
+      blitYOffset + height,
+      gl.COLOR_BUFFER_BIT,
+      gl.LINEAR
+    );
 
-    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, blitCopyHackFB);
-    state.bindTexture(gl.TEXTURE_2D_ARRAY, this.glTexture);
-    gl.copyTexSubImage3D(gl.TEXTURE_2D_ARRAY, 0, xOffset, yOffset, layerIdx, 0, 0, width, height);
+    if (useBlitHack) {
+      gl.bindFramebuffer(gl.READ_FRAMEBUFFER, blitCopyHackFB);
+      gl.copyTexSubImage3D(gl.TEXTURE_2D_ARRAY, 0, xOffset, yOffset, layerIdx, 0, 0, width, height);
+    }
 
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
 
     gl.deleteTexture(resizeTexture);
-    gl.deleteTexture(blitCopyHackTexture);
-    gl.deleteFramebuffer(blitCopyHackFB);
+
+    if (useBlitHack) {
+      gl.deleteTexture(blitCopyHackTexture);
+      gl.deleteFramebuffer(blitCopyHackFB);
+    }
 
     this.genMipmaps(layerIdx, atlasIdx);
   }
@@ -531,17 +567,8 @@ export default class WebGLAtlasTexture extends Texture {
     const r = atlasIdx % layer.colls;
     const c = Math.floor(atlasIdx / layer.rows);
 
-    // Blitting to a non 0 layer is broken on mobile, workaround by blitting then copying
-    // see https://jsfiddle.net/nu1xdgs3/13a
-    const blitCopyHackTexture = gl.createTexture();
-    const blitCopyHackFB = gl.createFramebuffer();
-    state.activeTexture(gl.TEXTURE0);
-    state.bindTexture(gl.TEXTURE_2D, blitCopyHackTexture);
-    gl.bindFramebuffer(gl.FRAMEBUFFER, blitCopyHackFB);
-    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, blitCopyHackTexture, 0);
-    gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA8, size, size);
+    const [blitCopyHackTexture, blitCopyHackFB] = createBlitCopyFramebuffer(gl, state, size, size, this.glTexture);
 
-    state.bindTexture(gl.TEXTURE_2D_ARRAY, this.glTexture);
     const mips = this.mipFramebuffers[layerIdx];
     while (curSize >= 2 && mipLevel <= this.mipLevels) {
       const srcX = r * prevSize;
@@ -551,15 +578,28 @@ export default class WebGLAtlasTexture extends Texture {
 
       const destX = r * curSize;
       const destY = c * curSize;
-      // const destX2 = destX + curSize;
-      // const destY2 = destY + curSize;
 
       gl.bindFramebuffer(gl.READ_FRAMEBUFFER, mips[mipLevel - 1]);
-      gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, blitCopyHackFB);
-      gl.blitFramebuffer(srcX, srcY, srcX2, srcY2, 0, 0, curSize, curSize, gl.COLOR_BUFFER_BIT, gl.LINEAR);
+      gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, useBlitHack ? blitCopyHackFB : mips[mipLevel]);
+      const blitXOffset = useBlitHack ? 0 : destX;
+      const blitYOffset = useBlitHack ? 0 : destY;
+      gl.blitFramebuffer(
+        srcX,
+        srcY,
+        srcX2,
+        srcY2,
+        blitXOffset,
+        blitYOffset,
+        blitXOffset + curSize,
+        blitYOffset + curSize,
+        gl.COLOR_BUFFER_BIT,
+        gl.LINEAR
+      );
 
-      gl.bindFramebuffer(gl.READ_FRAMEBUFFER, blitCopyHackFB);
-      gl.copyTexSubImage3D(gl.TEXTURE_2D_ARRAY, mipLevel, destX, destY, layerIdx, 0, 0, curSize, curSize);
+      if (useBlitHack) {
+        gl.bindFramebuffer(gl.READ_FRAMEBUFFER, blitCopyHackFB);
+        gl.copyTexSubImage3D(gl.TEXTURE_2D_ARRAY, mipLevel, destX, destY, layerIdx, 0, 0, curSize, curSize);
+      }
 
       prevSize = curSize;
       mipLevel++;
@@ -567,6 +607,11 @@ export default class WebGLAtlasTexture extends Texture {
     }
 
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
+    if (useBlitHack) {
+      gl.deleteTexture(blitCopyHackTexture);
+      gl.deleteFramebuffer(blitCopyHackFB);
+    }
   }
 
   removeTexture(texture: Texture) {

--- a/src/WebGLAtlasTexture.ts
+++ b/src/WebGLAtlasTexture.ts
@@ -60,8 +60,8 @@ export interface WebGLAtlasTextureOptions {
 
 // Blitting to a non 0 layer is broken on mobile, workaround by blitting then copying
 // see https://jsfiddle.net/nu1xdgs3/13a
-// This hack breaks mip map generation on some Mac OS computers, so we disable it there.
-const useBlitHack = !/mac os/i.test(navigator.userAgent);
+// This hack breaks mip map generation on some Mac OS computers, so we only want to enable it on Android devices.
+const useBlitHack = /android/i.test(navigator.userAgent);
 
 function createBlitCopyFramebuffer(
   gl: WebGL2RenderingContext,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
   MeshBasicMaterial
 } from "three";
 import WebGLAtlasTexture from "./WebGLAtlasTexture";
-import { vertexShader, fragmentShader, BatchRawUniformGroup, InstanceID } from "./UnlitBatchShader";
+import { vertexShader, fragmentShader, BatchRawUniformGroup } from "./UnlitBatchShader";
 
 interface BatchableBufferGeometry extends BufferGeometry {
   attributes: {


### PR DESCRIPTION
This PR fixes an image batching issue we've noticed on macOS computers (probably specific to macbooks that use Intel integrated graphics chipsets). The bug caused mip maps to generate incorrectly, where all mip maps would be copied to the first texture level instead of on their appropriate mip levels.

It turns out that skipping the blit copy hack that we added for Android devices in #16 fixes the issue on macOS, though I'm not entirely sure why.
In investigating the issue, I found that it may be related to memory limits on the macbook chipsets, since they are limited to 1.5GB. (I reproduced this on a MacBook Pro, 13-inch, 2018 with Intel Iris Plus Graphics 655). Reducing the layer resolution or initial texture array depth would also work around the bug.

The PR also adds a simpler example that demonstrates image batching alone.