### PR TITLE
Skip batching for non-indexed meshes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -334,6 +334,11 @@ export class BatchManager {
 
     const batches = this.batches;
 
+    if (!batchableMesh.geometry.index) {
+      console.warn("Non-indexed mesh, skipping.", mesh);
+      return false;
+    }
+
     const indexCount = batchableMesh.geometry.index.count;
     const vertCount = batchableMesh.geometry.attributes.position.count;
 


### PR DESCRIPTION
Non indexed meshes are failing when trying to access the `.count` property. This is causing some issues in Spoke and likely in Hubs as well.